### PR TITLE
Fix ui ingestion runner entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,7 +375,7 @@ services:
     volumes:
       - ./scripts:/scripts:ro
     working_dir: /scripts
-    command: ["python", "-u", "ui_ingestion_runner.py"]
+    entrypoint: ["python", "-u", "ui_ingestion_runner.py"]
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- run the UI ingestion runner container via python directly so it no longer invokes the datahub CLI entrypoint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d119c78a90832cb18e6a05b8d6a61f