### PR TITLE
Mount actions into UI ingestion runner container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -374,6 +374,7 @@ services:
       - UI_RUNNER_POLL_INTERVAL=15
     volumes:
       - ./scripts:/scripts:ro
+      - ./actions:/actions:ro
     working_dir: /scripts
     entrypoint: ["python", "-u", "ui_ingestion_runner.py"]
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- mount the actions directory into the ui-ingestion-runner container so the helper can import custom actions

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d11cd2ac40832c9ba62c1aad2a7692