### PR TITLE
Fix ingestion runner entrypoint with health checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ingest:
 	    sleep 5; \
 	  done; \
 	  echo 'datahub-gms is healthy, starting ingestion'; \
-	  DATAHUB_GMS_URL=http://datahub-gms:8080 DATAHUB_GMS_HOST=datahub-gms DATAHUB_GMS_PORT=8080 DATAHUB_GMS_PROTOCOL=http datahub ingest run -c /ingest/postgres_recipe.yml"
+	  DATAHUB_GMS_URL=http://datahub-gms:8080 DATAHUB_GMS_HOST=datahub-gms DATAHUB_GMS_PORT=8080 DATAHUB_GMS_PROTOCOL=http datahub ingest run -c /workspace/ingest/recipe.yml"
 
 down:
 	$(DC) down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -306,21 +306,23 @@ services:
     restart: unless-stopped
 
   ingestion:
-    image: acryldata/datahub-ingestion:v1.2.0.1
+    build:
+      context: .
+      dockerfile: docker/ingestion-runner/Dockerfile
     depends_on:
       datahub-gms:
         condition: service_healthy
       postgres:
         condition: service_healthy
     environment:
-      - DATAHUB_GMS_URL=http://datahub-gms:8080
-      - DATAHUB_GMS_PROTOCOL=http
-      - DATAHUB_GMS_HOST=datahub-gms
-      - DATAHUB_GMS_PORT=8080
+      DATAHUB_GMS_URI: http://datahub-gms:8080
+      RECIPE_FILE: /workspace/ingest/recipe.yml
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DATAHUB_TOKEN: ${DATAHUB_TOKEN:-}
     volumes:
-      - ./ingest:/ingest:ro
-    working_dir: /ingest
-    command: ["sleep", "infinity"]
+      - ./ingest:/workspace/ingest:ro
+    working_dir: /workspace
 
   postgres:
     image: postgres:15-alpine

--- a/docker/ingestion-runner/Dockerfile
+++ b/docker/ingestion-runner/Dockerfile
@@ -1,0 +1,6 @@
+FROM acryldata/datahub-ingestion:v1.2.0.1
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+# shellcheck shell=sh
+
+if ! set -euo pipefail 2>/dev/null; then
+  set -eu
+  # shellcheck disable=SC3040
+  set -o pipefail 2>/dev/null || true
+fi
+
+log() {
+  printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+random_sleep() {
+  python3 - "$1" <<'PY'
+import random
+import sys
+base = float(sys.argv[1])
+# Add up to 1 second of jitter
+sleep_for = base + random.random()
+print(f"{sleep_for:.2f}")
+PY
+}
+
+retry() {
+  desc=$1
+  shift
+  attempt=1
+  delay=${RETRY_INITIAL_DELAY:-2}
+  max_attempts=${RETRY_MAX_ATTEMPTS:-20}
+  backoff=${RETRY_BACKOFF_MULTIPLIER:-2}
+  max_delay=${RETRY_MAX_DELAY:-30}
+
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if "$@"; then
+      log "$desc succeeded (attempt $attempt)"
+      return 0
+    fi
+
+    if [ "$attempt" -eq "$max_attempts" ]; then
+      log "$desc failed after $attempt attempts"
+      return 1
+    fi
+
+    attempt=$((attempt + 1))
+    sleep_for=$(random_sleep "$delay")
+    log "$desc retrying in ${sleep_for}s (attempt $attempt of $max_attempts)"
+    sleep "$sleep_for"
+
+    if [ "$delay" -lt "$max_delay" ]; then
+      delay=$((delay * backoff))
+      if [ "$delay" -gt "$max_delay" ]; then
+        delay=$max_delay
+      fi
+    fi
+  done
+
+  return 1
+}
+
+check_gms() {
+  curl -fsS --max-time "${GMS_HEALTH_TIMEOUT:-5}" "$DATAHUB_GMS_URI/api/health" >/tmp/gms-health.json
+}
+
+check_db() {
+  python3 - "$DB_HOST" "$DB_PORT" <<'PY'
+import socket
+import sys
+host = sys.argv[1]
+port = int(sys.argv[2])
+with socket.create_connection((host, port), timeout=5):
+    pass
+PY
+}
+
+main() {
+  DATAHUB_GMS_URI=${DATAHUB_GMS_URI:-http://datahub-gms:8080}
+  export DATAHUB_GMS_URI
+  RECIPE_FILE=${RECIPE_FILE:-/workspace/ingest/recipe.yml}
+  DB_HOST=${DB_HOST:-postgres}
+  DB_PORT=${DB_PORT:-5432}
+  STARTUP_DELAY=${STARTUP_DELAY:-5}
+
+  log "Starting ingestion runner"
+  log "Using recipe file: $RECIPE_FILE"
+  log "Waiting for DataHub GMS health at $DATAHUB_GMS_URI/api/health"
+  retry "DataHub GMS health check" check_gms
+  if [ -f /tmp/gms-health.json ]; then
+    log "DataHub GMS health payload: $(tr -d '\n' </tmp/gms-health.json)"
+    rm -f /tmp/gms-health.json
+  fi
+
+  log "Waiting for database availability at $DB_HOST:$DB_PORT"
+  retry "Database connectivity check" check_db
+
+  case "${STARTUP_DELAY}" in
+    ''|0)
+      ;;
+    *)
+      log "Startup delay requested: sleeping ${STARTUP_DELAY}s"
+      sleep "$STARTUP_DELAY"
+      ;;
+  esac
+
+  if [ ! -f "$RECIPE_FILE" ]; then
+    log "Recipe file not found: $RECIPE_FILE"
+    exit 1
+  fi
+
+  log "Health checks passed. Executing ingestion"
+  exec datahub ingest -c "$RECIPE_FILE"
+}
+
+main "$@"

--- a/ingest/recipe.yml
+++ b/ingest/recipe.yml
@@ -1,0 +1,19 @@
+pipeline_name: postgres_local_poc
+
+source:
+  type: postgres
+  config:
+    host_port: postgres:5432
+    database: postgres
+    username: datahub
+    password: datahub
+    schema_pattern:
+      allow:
+        - public.*
+    profiling:
+      enabled: false
+
+sink:
+  type: datahub-rest
+  config:
+    server: http://datahub-gms:8080

--- a/scripts/test_ingestion_runner.sh
+++ b/scripts/test_ingestion_runner.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="$(mktemp -t ingestion-run-XXXX.log)"
+trap 'rm -f "$log_file"' EXIT
+
+echo "[test] Running ingestion container via docker compose"
+if docker compose run --rm ingestion >"$log_file" 2>&1; then
+  if [ ! -s "$log_file" ]; then
+    echo "[test] Ingestion logs were empty" >&2
+    cat "$log_file" >&2 || true
+    exit 1
+  fi
+  echo "[test] Ingestion completed successfully with output:"
+  cat "$log_file"
+else
+  status=$?
+  echo "[test] Ingestion container exited with status $status" >&2
+  cat "$log_file" >&2 || true
+  exit "$status"
+fi


### PR DESCRIPTION
## Summary
- add a shell entrypoint that waits for DataHub GMS and Postgres before invoking the DataHub CLI
- build a custom ingestion runner image that ships the entrypoint and update docker compose, Makefile, and docs to use /workspace/ingest/recipe.yml
- provide a helper recipe copy and a smoke-test script for running the ingestion container non-interactively

## Testing
- ⚠️ `docker compose build ingestion` *(fails in CI sandbox because docker is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d1298823f8832cb2869e39495294e2