### PR TITLE
Improve UI ingestion runner health checks and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Sample environment overrides for the UI ingestion runner
+DATAHUB_GMS_URI=http://datahub-gms:8080
+DATAHUB_TOKEN=
+DATAHUB_ACTOR=urn:li:corpuser:ui_ingestion_runner
+HEALTH_CHECK_PATHS=/admin,/api/graphiql,/api/graphql,/actuator/health,/health

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,8 @@ progressbar2==4.5.0
 propcache==0.3.2
 psutil==7.1.0
 psycopg[binary]==3.2.10
-pydantic==2.11.9
-pydantic_core==2.33.2
+pydantic>=2.11.0
+pydantic_core>=2.33.2
 python-dateutil==2.9.0.post0
 python-utils==3.9.1
 PyYAML==6.0.2

--- a/tests/test_ui_ingestion_runner_health.py
+++ b/tests/test_ui_ingestion_runner_health.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+import pytest
+import requests
+
+from scripts import ui_ingestion_runner as runner
+
+
+class MockResponse:
+    def __init__(
+        self,
+        status_code: int,
+        text: str = "",
+        json_data: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.status_code = status_code
+        self._json_data = json_data
+        if text:
+            self.text = text
+        elif json_data is not None:
+            self.text = json.dumps(json_data)
+        else:
+            self.text = ""
+
+    def json(self) -> Dict[str, Any]:
+        if self._json_data is None:
+            raise ValueError("No JSON payload configured")
+        return self._json_data
+
+
+def _build_graphql_response() -> MockResponse:
+    payload = {"data": {"__schema": {"queryType": {"name": "Query"}}}}
+    return MockResponse(200, json_data=payload)
+
+
+def test_health_check_falls_back_to_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_url = "http://datahub-gms:8080"
+    session = requests.Session()
+
+    responses: Dict[str, MockResponse] = {
+        f"{base_url}/api/health": MockResponse(404, text="not found"),
+        f"{base_url}/admin": MockResponse(200, text="ok"),
+        f"{base_url}/api/graphql": _build_graphql_response(),
+    }
+
+    call_log: list[tuple[str, str]] = []
+
+    def fake_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        call_log.append((method.upper(), url))
+        response = responses.get(url)
+        if response is None:
+            raise AssertionError(f"Unexpected URL requested: {url}")
+        return response
+
+    monkeypatch.setattr(session, "request", fake_request)
+    monkeypatch.setattr(runner, "GMS_URL_ENV", base_url)
+    monkeypatch.setattr(runner, "GMS_URL", base_url)
+    monkeypatch.setattr(runner, "DATAHUB_TOKEN", None)
+    monkeypatch.setattr(runner, "HEALTH_CHECK_PATHS", [
+        "/api/health",
+        "/admin",
+        "/api/graphql",
+    ])
+
+    resolved = runner.resolve_gms_url(session, {})
+
+    assert resolved == base_url
+    assert ("GET", f"{base_url}/api/health") in call_log
+    assert ("GET", f"{base_url}/admin") in call_log
+    assert ("POST", f"{base_url}/api/graphql") in call_log
+
+
+def test_health_check_accepts_graphql_when_rest_endpoints_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url = "http://datahub-gms:8080"
+    session = requests.Session()
+
+    responses: Dict[str, MockResponse] = {
+        f"{base_url}/api/health": MockResponse(404, text="missing"),
+        f"{base_url}/admin": MockResponse(404, text="missing"),
+        f"{base_url}/api/graphiql": MockResponse(404, text="missing"),
+        f"{base_url}/api/graphql": _build_graphql_response(),
+    }
+
+    def fake_request(method: str, url: str, **kwargs: Any) -> MockResponse:
+        response = responses.get(url)
+        if response is None:
+            raise AssertionError(f"Unexpected URL requested: {url}")
+        return response
+
+    monkeypatch.setattr(session, "request", fake_request)
+    monkeypatch.setattr(runner, "GMS_URL_ENV", base_url)
+    monkeypatch.setattr(runner, "GMS_URL", base_url)
+    monkeypatch.setattr(runner, "DATAHUB_TOKEN", None)
+    monkeypatch.setattr(runner, "HEALTH_CHECK_PATHS", [
+        "/api/health",
+        "/admin",
+        "/api/graphiql",
+        "/api/graphql",
+    ])
+
+    resolved = runner.resolve_gms_url(session, {})
+
+    assert resolved == base_url


### PR DESCRIPTION
## Summary
- harden the UI ingestion runner health probe with retrying fallbacks, GraphQL introspection, configurable headers/paths, and a Pydantic v2 config patch
- document the new runner environment knobs in README and ship a .env.example to simplify overrides
- add focused unit tests that exercise the fallback and GraphQL success cases

## Testing
- pytest tests/test_ui_ingestion_runner_health.py

------
https://chatgpt.com/codex/tasks/task_e_68d150208c5c832c8e9339423a188ce2